### PR TITLE
fix: adding offset clamp

### DIFF
--- a/langchain_apify/tools.py
+++ b/langchain_apify/tools.py
@@ -372,6 +372,9 @@ class _ApifyGenericTool(BaseTool):  # type: ignore[override]
     def _clamp_items(self, value: int) -> int:
         return max(1, min(value, self.max_items))
 
+    def _clamp_offset(value: int) -> int:
+        return max(0, value)
+
 
 # ---------------------------------------------------------------------------
 # Generic tools
@@ -478,7 +481,7 @@ class ApifyGetDatasetItemsTool(_ApifyGenericTool):  # type: ignore[override]
         _run_manager: CallbackManagerForToolRun | None = None,
     ) -> str:
         try:
-            items = self._client.get_dataset_items(dataset_id, self._clamp_items(limit), offset)
+            items = self._client.get_dataset_items(dataset_id, self._clamp_items(limit), self._clamp_offset(offset))
         except RuntimeError as exc:
             raise ToolException(str(exc)) from exc
         if not items:

--- a/tests/unit_tests/test_tools.py
+++ b/tests/unit_tests/test_tools.py
@@ -572,6 +572,22 @@ def test_clamp_items_floor_is_one(mock_tools_client: MagicMock) -> None:
     mock_tools_client.get_dataset_items.assert_called_once_with('ds-1', 1, 0)
 
 
+def test_clamp_offset_floor_is_zero(mock_tools_client: MagicMock) -> None:
+    mock_tools_client.get_dataset_items.return_value = SAMPLE_ITEMS
+    tool = make_tool(ApifyGetDatasetItemsTool, mock_tools_client, max_items=100)
+
+    tool._run(dataset_id='ds-1', offset=-5)
+    mock_tools_client.get_dataset_items.assert_called_once_with('ds-1', 100, 0)
+
+    mock_tools_client.get_dataset_items.reset_mock()
+    tool._run(dataset_id='ds-1', offset=0)
+    mock_tools_client.get_dataset_items.assert_called_once_with('ds-1', 100, 0)
+
+    mock_tools_client.get_dataset_items.reset_mock()
+    tool._run(dataset_id='ds-1', offset=10)
+    mock_tools_client.get_dataset_items.assert_called_once_with('ds-1', 100, 10)
+
+
 def test_values_below_max_pass_through(mock_tools_client: MagicMock) -> None:
     """When LLM values are within limits they should pass through unchanged."""
     mock_tools_client.run_actor.return_value = SUCCEEDED_RUN


### PR DESCRIPTION
## Summary

- Add `_clamp_offset` to `_ApifyGenericTool` that floors the `offset` parameter to `0`, preventing invalid negative values from being sent to the Apify API
- Apply the clamp in `ApifyGetDatasetItemsTool._run` where `offset` was previously passed through unchecked

## Motivation

The `limit` parameter in `ApifyGetDatasetItemsTool` was already clamped via `_clamp_items`, but the `offset` parameter was passed directly to the API without validation. Per the [Apify Get Dataset Items API](https://docs.apify.com/api/v2/dataset-items-get#request), `offset` is a non-negative number (default `0`) representing the number of items to skip. Negative values are invalid and could cause unexpected API behavior. It is especially necessary to minimise inappropriate token usage. 

## Changes

- **`langchain_apify/tools.py`** — Added `_clamp_offset` static method to `_ApifyGenericTool` that ensures `offset >= 0`. Applied it in `ApifyGetDatasetItemsTool._run`.
- **`tests/unit_tests/test_tools.py`** — Added `test_clamp_offset_floor_is_zero` covering three cases: negative offset is clamped to 0, zero passes through, and positive values pass through unchanged.