### PR TITLE
chore: update dependencies and modernize project config

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2840,4 +2840,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "f536d920e814b92fcc10e8a335ac79e0d20b3c877afbc3b5a125cafe50c74e72"
+content-hash = "41fd709c5e597a39a8bb951ffd9a0ed0d9a9ec5ed24b236cf28e42824ac98482"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,30 +1,30 @@
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.poetry]
+[project]
 name = "langchain-apify"
 version = "0.1.6"
 description = "An integration package connecting Apify and LangChain"
-authors = ["Apify Technologies s.r.o. <support@apify.com>"]
+authors = [{ name = "Apify Technologies s.r.o.", email = "support@apify.com" }]
 readme = "README.md"
-repository = "https://github.com/apify/langchain-apify"
 license = "Apache-2.0"
+requires-python = ">=3.10,<4.0"
+dependencies = [
+    "langchain-core>=0.3.15,<2.0.0",
+    "apify-client>=2.3.0,<3.0.0",
+    "eval-type-backport>=0.2.2",
+]
 
-[tool.mypy]
-disallow_untyped_defs = true
-
-[tool.poetry.urls]
+[project.urls]
 "Apify Homepage" = "https://apify.com"
+"Repository" = "https://github.com/apify/langchain-apify"
 "Source Code" = "https://github.com/apify/langchain-apify/tree/main/"
 "Release Notes" = "https://github.com/apify/langchain-apify/releases?expanded=true"
 "Issue Tracker" = "https://github.com/apify/langchain-apify/issues"
 
-[tool.poetry.dependencies]
-python = ">=3.10,<4.0"
-langchain-core = ">=0.3.15,<2.0.0"
-apify-client = "^2.3.0"
-eval-type-backport = ">=0.2.2"
+[tool.mypy]
+disallow_untyped_defs = true
 
 [tool.ruff]
 line-length = 120

--- a/tests/unit_tests/test_tools.py
+++ b/tests/unit_tests/test_tools.py
@@ -673,7 +673,7 @@ def test_generic_tools_have_correct_metadata() -> None:
         'apify_run_task_and_get_dataset',
     ]
 
-    for tool, expected_name in zip(tools, expected_names):
+    for tool, expected_name in zip(tools, expected_names, strict=True):
         assert tool.name == expected_name
         assert tool.description
         assert tool.args_schema is not None


### PR DESCRIPTION
## Migrate `pyproject.toml` to a PEP 621 `[project]` table

The release workflow bumps the version with `uv version`, which writes to
`[project].version`. This repo declared metadata under legacy `[tool.poetry]`,
so the release failed at the bump step with `error: No `project` table found`.
This moves the core metadata to `[project]`, sets
`requires = ["poetry-core>=2.0.0"]`, and regenerates `poetry.lock`. Format-only:
dependency versions, package contents, and runtime behavior are unchanged.

> Verified locally: `uv version` reads `langchain-apify 0.1.6` (previously
> failed), `poetry build` produces sdist + wheel, `twine check` PASSED,
> `poetry check` reports "All set!". Wheel METADATA is unchanged on name,
> version, deps, and markdown README.

### What changed

| File | Change |
| -- | -- |
| `pyproject.toml` | `[tool.poetry]` metadata → `[project]` (name, static `version`, description, authors, readme, license, `requires-python`, `dependencies`, `[project.urls]`); `poetry-core>=1.0.0` → `>=2.0.0` |
| `poetry.lock` | Regenerated: `content-hash` line only, no dependency version changes |
| `tests/unit_tests/test_tools.py` | `zip(..., strict=True)` in the tool-metadata test: the migration lets ruff infer py310 and enforce `B905`, which was silently skipped before |

Left untouched: the `[tool.poetry.group.*]` dev/test groups, the
`apify-client` / `langchain-core` / `eval-type-backport` constraints, and the
`0.1.6` version string (the release workflow sets the real number).